### PR TITLE
Replace old `jw` name in missed locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository contains the Jour tool, an utility for a high-level machine main
 
 Some examples of the usage of this tool could be:
 
-1. Write a journal to keep track of an operating system update you just ran:
+1. Write a journal entry to register an OS update. Just run the following command in the terminal:
 
 ```sh
-jw -w 'OS update to 24.5.2'
+jour --write 'OS update to 24.5.2'
 ```
 
 Output:
@@ -16,10 +16,10 @@ Output:
 0014. 2024-03-16 17:04:50,123 - test_username - OS update to 24.5.2.
 ```
 
-2. Write a journal entry about a backup of the machine. Use a tag.
+2. Write a journal entry about a backup of the machine. Use a Jour tag.
 
 ```sh
-jw -w 'General system backup' && w -t BUP
+jour --write 'General system backup' && jour --tag 'BUP'
 ```
 
 Output:
@@ -28,13 +28,25 @@ Output:
 0015. 2024-03-16 17:06:08,630 - test_username - General system backup. #BUP1
 ```
 
-You could then use this same tag `BUP1` to also tag a commit in a Git repository with your machine config. This way your journal and your machine config are paired.
+3. Register other backup some time later. Use the same tag. Take into account that the tag index is automatically incremented, like the entry index.
+
+```sh
+jour --write 'General system backup' && jour --tag 'BUP'
+```
+
+Output:
+
+```
+0016. 2024-03-16 17:09:14,123 - test_username - General system backup. #BUP2
+```
+
+You could then use these same tags `BUP1`, `BUP2`, etc. to also tag a commit in a Git repository with your machine config or dotfiles. This way your Jour journal and your machine config are paired.
 
 ### The journal file
 
-Basically, each new journal entry is a new line in the journal file, with an index and a date. The index is useful to cross-reference the journal entries. The entries are appended to the journal file sequentially. The journal file location is defined in the environment variable `$JOURNAL` (or, by default in `~/.journal.md`). If the tool cannot reach the file, the incoming entries are stored in an emergency journal file, which location is `$JOURNAL_EMERGENCY`, if defined, or `~/.journal_emergency.md`, otherwise. This is useful if, for example, the journal file is located in a remote file system or cloud provider and the connection is lost. The user can then manually arrange the journal entries merging the emergency journal.
+Basically, each new journal entry is a new line in the journal file, with an index and a date. The index is useful to cross-reference the journal entries. The entries are appended to the journal file sequentially. The journal file location is defined in the environment variable `$JOURNAL` (or, by default in `~/journal.md`). If the tool cannot reach the file, the incoming entries are stored in an emergency journal file, which location is `$JOURNAL_EMERGENCY`, if defined, or `~/journal_emergency.md`, otherwise. This is useful if, for example, the journal file is located in a remote file system or cloud provider and the connection is lost. The user can then manually arrange the journal entries merging the emergency journal.
 
-In addition to the entries, the tool also handle tags, like `#backup1`, to an easier navigation of the journal file. This is specially useful to link the journal entries with tags in a configuration Git repository, for example, because a journal tag can be also set in the repo.
+In addition to the entries, like explained before, the tool also handle tags, like `#BUP1`, to an easier navigation of the journal file. This is specially useful to link the journal entries with tags in a configuration Git repository, for example, because a journal tag can be also set in the repo.
 
 Journal format is Markdown, so the user can also export all the history to a more readable format, like a PDF, using a Markdown to PDF converter.
 

--- a/jour/__main__.py
+++ b/jour/__main__.py
@@ -2,7 +2,7 @@
 Main
 ====
 
-This module is the main entry point for the `jw` command line utility. It uses the
+This module is the main entry point for the `jour` command line utility. It uses the
 `argparse` module to parse the command line arguments and the `Jour` class
 to access the functionality.
 """
@@ -27,7 +27,7 @@ logger.addHandler(handler)
 def parse_args():
     # Define the parser
     parser = argparse.ArgumentParser(
-        prog="jw",
+        prog="jour",
         description="An utility for a high-level machine maintenance journal. Uses the file defined in `JOURNAL` environment variable as the journal file location",
         epilog="© Borja González Seoane",
     )
@@ -131,32 +131,32 @@ def main():
         return
 
     # Create a `Jour` object
-    jw = Jour(create_journal=args.create_journal)
+    jour = Jour(create_journal=args.create_journal)
 
     # Enter context an run the command
-    with jw:
+    with jour:
         if args.write:
-            jw.write_line(
+            jour.write_line(
                 args.MESSAGE_OR_TAG,
                 as_command=args.as_command,
                 signature=args.signature,
                 printing=True,
             )
         elif args.append:
-            jw.append_to_last_line(
+            jour.append_to_last_line(
                 args.MESSAGE_OR_TAG, as_command=args.as_command, printing=True
             )
         elif args.tag:
-            jw.tag_last_line(args.MESSAGE_OR_TAG, printing=True)
+            jour.tag_last_line(args.MESSAGE_OR_TAG, printing=True)
 
         elif args.return_tag:
-            jw.get_next_tag(args.MESSAGE_OR_TAG, printing=True)
+            jour.get_next_tag(args.MESSAGE_OR_TAG, printing=True)
 
         elif args.remove:
-            jw.remove_last_line()
+            jour.remove_last_line()
 
         else:  # Default
-            jw.print_journal()
+            jour.print_journal()
 
 
 if __name__ == "__main__":

--- a/jour/jour.py
+++ b/jour/jour.py
@@ -100,16 +100,6 @@ class Jour:
             "".join(self._journal), options={"number": True, "wrap": "keep"}
         )
 
-        # However Mdformat's, preserve the line index format with four digits, that is considered
-        # here as a particularity of the type of file to facilitate reading
-        now = datetime.datetime.now().strftime(
-            "%Y-%m"
-        )  # Used for protect the following replacement, affecting only the line index and not other possible numbers in the journal
-        for i, _ in enumerate(journal_fmt.split("\n")):
-            journal_fmt = journal_fmt.replace(
-                f"{i+1}. {now}", f"{str(i+1).zfill(4)}. {now}"
-            )
-
         with self._journal_lock:
             # Write the journal back to the file
             with open(self._active_journal_file, "w") as f:
@@ -312,9 +302,6 @@ class Jour:
         # Calculate the next index
         if index is None:
             index = self.__calculate_next_line_index()
-
-        # Fix next index to have a fixed length
-        index = str(index).zfill(4)
 
         # Solve signature
         if not signature:

--- a/jour/jour.py
+++ b/jour/jour.py
@@ -80,7 +80,7 @@ class Jour:
         )  # Debug level
 
         self._journal_lock = ILock(
-            f"jw_lock_{self._active_journal_file.name}", reentrant=True, timeout=10
+            f"jour_lock_{self._active_journal_file.name}", reentrant=True, timeout=10
         )
         with self._journal_lock:
             # Load the journal file to memory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ license = "LICENSE"
 name = "jour"
 readme = "README.md"
 repository = "https://github.com/bglezseoane/jour"
-version = "2.0.0"
+version = "2.0.1"
 
 [tool.poetry.dependencies]
 ilock = "^1.0.3"

--- a/tests/test_jour.py
+++ b/tests/test_jour.py
@@ -40,8 +40,8 @@ class TestJour(unittest.TestCase):
         Test that an error is raised if the `Jour` is not used as a context manager.
         """
         with self.assertRaises(RuntimeError) as cm:
-            jw = Jour()
-            jw.print_journal()
+            jour = Jour()
+            jour.print_journal()
 
         self.assertEqual(str(cm.exception), "`Jour` context not found.")
 
@@ -58,23 +58,23 @@ class TestJour(unittest.TestCase):
         and the `create_journal` flag is set to `False`. Test also that the emergency journal is
         used as target journal in this case.
         """
-        jw = Jour(create_journal=False)
-        with jw:
+        jour = Jour(create_journal=False)
+        with jour:
             self.assertFalse(os.path.isfile(self.journal_file))
             self.assertTrue(os.path.isfile(self.journal_emergency_file))
 
         # Test that the emergency journal is used as target journal
-        self.assertNotEqual(jw._active_journal_file, self.journal_file)
-        self.assertEqual(jw._active_journal_file, self.journal_emergency_file)
+        self.assertNotEqual(jour._active_journal_file, self.journal_file)
+        self.assertEqual(jour._active_journal_file, self.journal_emergency_file)
 
     def test_write_line_and_file_dumping(self):
         """
         Test that the `write_line` method appends a new line to the journal file. The journal file
         is created, so actually two lines should be present in the journal file.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("Test message")
-            self.assertEqual(len(jw._journal), 2)
+        with Jour(create_journal=True) as jour:
+            jour.write_line("Test message")
+            self.assertEqual(len(jour._journal), 2)
 
         # Assert also that the content of the journal in memory is dumped to the journal file
         with open(self.journal_file, "r") as f:
@@ -90,26 +90,26 @@ class TestJour(unittest.TestCase):
         """
         Assert content is correctly appended to the last line of the journal.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("Test message")
-            jw.append_to_last_line("Additional message")
-            self.assertIn("Test message. Additional message.", jw._journal[-1])
+        with Jour(create_journal=True) as jour:
+            jour.write_line("Test message")
+            jour.append_to_last_line("Additional message")
+            self.assertIn("Test message. Additional message.", jour._journal[-1])
 
     def test_remove_last_line(self):
         """
         Assert that remove the last line of the journal works as expected.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("Test message")
-            jw.remove_last_line()
-            self.assertEqual(len(jw._journal), 1)  # One line is the creation message
+        with Jour(create_journal=True) as jour:
+            jour.write_line("Test message")
+            jour.remove_last_line()
+            self.assertEqual(len(jour._journal), 1)  # One line is the creation message
 
     def test_get_next_tag(self):
         """
         Assert that the `get_next_tag` method returns the next tag to be used in the journal.
         """
-        with Jour(create_journal=True) as jw:
-            next_tag = jw.get_next_tag("Tag")
+        with Jour(create_journal=True) as jour:
+            next_tag = jour.get_next_tag("Tag")
             self.assertEqual(next_tag, "#Tag1")
 
     def test_tag_last_line(self):
@@ -117,27 +117,27 @@ class TestJour(unittest.TestCase):
         Assert the tagging of the last line of the journal works as expected. Tag index should be
         increased.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("Test message")
-            jw.write_line("Other message")
-            jw.tag_last_line("ExampleTag")
-            self.assertIn("#ExampleTag1", jw._journal[-1])
+        with Jour(create_journal=True) as jour:
+            jour.write_line("Test message")
+            jour.write_line("Other message")
+            jour.tag_last_line("ExampleTag")
+            self.assertIn("#ExampleTag1", jour._journal[-1])
 
             # Add other instance of the tag
-            jw.tag_last_line("ExampleTag")
-            self.assertIn("#ExampleTag2", jw._journal[-1])
+            jour.tag_last_line("ExampleTag")
+            self.assertIn("#ExampleTag2", jour._journal[-1])
 
     def test_print_journal_and_default_signature(self):
         """
         Test that the `print_journal` method prints the last lines of the journal as
         expected. Test also signature is added in lines.
         """
-        with Jour(create_journal=True) as jw:
+        with Jour(create_journal=True) as jour:
             for i in range(1, 25):
-                jw.write_line(f"Message {i+1}")
+                jour.write_line(f"Message {i+1}")
 
             with patch("jour.jour.logger.info") as mock_logger:
-                jw.print_journal()
+                jour.print_journal()
 
                 # Assert that the `logger.info` method is called with the expected lines,
                 # which are the last 10 lines of the journal
@@ -154,9 +154,9 @@ class TestJour(unittest.TestCase):
         Test that the signature is correctly added to the lines of the journal when a custom
         signature is provided.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("Message", signature="CustomSignature")
-            self.assertIn("CustomSignature", jw._journal[-1])
+        with Jour(create_journal=True) as jour:
+            jour.write_line("Message", signature="CustomSignature")
+            self.assertIn("CustomSignature", jour._journal[-1])
 
     def test_using_an_existent_journal_file(self):
         """
@@ -167,13 +167,13 @@ class TestJour(unittest.TestCase):
             f.write("# Testing Journal\n")  # Header
             f.write("This is a testing journal only for testing purposes.\n")
 
-        with Jour() as jw:
-            self.assertEqual(jw._active_journal_file, self.journal_file)
+        with Jour() as jour:
+            self.assertEqual(jour._active_journal_file, self.journal_file)
 
             # Add a line to the journal
-            jw.write_line("Test message")
-            self.assertTrue(jw._journal[-1].startswith("1. "))
-            self.assertIn("Test message", jw._journal[-1])
+            jour.write_line("Test message")
+            self.assertTrue(jour._journal[-1].startswith("1. "))
+            self.assertIn("Test message", jour._journal[-1])
 
     def test_using_empty_file_as_journal(self):
         """
@@ -183,39 +183,39 @@ class TestJour(unittest.TestCase):
         with open(self.journal_file, "w"):
             pass
 
-        with Jour() as jw:
-            self.assertEqual(jw._active_journal_file, self.journal_file)
+        with Jour() as jour:
+            self.assertEqual(jour._active_journal_file, self.journal_file)
 
             # Catch message when the journal is empty
             with patch("jour.jour.logger.warning") as mock_logger:
-                jw.print_journal()
+                jour.print_journal()
                 self.assertEqual(mock_logger.call_args[0][0], "The journal is empty.")
 
             # Try to write a line to the journal
-            jw.write_line("Test message")
-            self.assertTrue(jw._journal[-1].startswith("1. "))
-            self.assertIn("Test message", jw._journal[-1])
+            jour.write_line("Test message")
+            self.assertTrue(jour._journal[-1].startswith("1. "))
+            self.assertIn("Test message", jour._journal[-1])
 
     def test_messages_formatting(self):
         """
         Test that the messages are correctly formatted when written to the journal.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("This is a test message", signature="Testing Custom Author")
+        with Jour(create_journal=True) as jour:
+            jour.write_line("This is a test message", signature="Testing Custom Author")
 
             # The line should be in format:
             # `0001. DD-MM-YYYY HH:MM:SS,sss - Testing Custom Author - This is a test message.`
-            self.assertEqual("2", jw._journal[-1].split(".")[0])
+            self.assertEqual("2", jour._journal[-1].split(".")[0])
             self.assertEqual(
                 datetime.datetime.now().strftime("%Y-%m-%d %H"),
-                jw._journal[-1]
+                jour._journal[-1]
                 .split(". ")[1]
                 .split(" - ")[0]
                 .split(":")[0],  # Ignore minutes, seconds and milliseconds
             )
-            self.assertEqual("Testing Custom Author", jw._journal[-1].split(" - ")[1])
+            self.assertEqual("Testing Custom Author", jour._journal[-1].split(" - ")[1])
             self.assertEqual(
-                "This is a test message.\n", jw._journal[-1].split(" - ")[2]
+                "This is a test message.\n", jour._journal[-1].split(" - ")[2]
             )
 
     def test_index_formatting_is_correct(self):
@@ -224,11 +224,11 @@ class TestJour(unittest.TestCase):
         journal to a file, the index should be padded with zeros to have a fixed length of the length
         of the highest index.
         """
-        with Jour(create_journal=True) as jw:
+        with Jour(create_journal=True) as jour:
             for _ in range(1, 20):
-                jw.write_line("Test message")
+                jour.write_line("Test message")
 
-            for i, line in enumerate(jw._journal):
+            for i, line in enumerate(jour._journal):
                 if i < 9:
                     self.assertEqual(f"{i+1}", line.split(".")[0])
                 else:
@@ -248,17 +248,17 @@ class TestJour(unittest.TestCase):
         """
         Test that the `as_command` flag formats the message as a command.
         """
-        with Jour(create_journal=True) as jw:
-            jw.write_line("brew install example", as_command=True)
-            self.assertIn(" - `brew install example`.\n", jw._journal[-1])
+        with Jour(create_journal=True) as jour:
+            jour.write_line("brew install example", as_command=True)
+            self.assertIn(" - `brew install example`.\n", jour._journal[-1])
 
     def test_warn_about_using_emergency_journal(self):
         """
         Test that a warning is logged when the emergency journal is used.
         """
         with patch("jour.jour.logger.warning") as mock_logger:
-            with Jour(create_journal=False) as jw:
-                jw.write_line("Test message")
+            with Jour(create_journal=False) as jour:
+                jour.write_line("Test message")
                 self.assertEqual(
                     f"Using emergency journal file in `{self.journal_emergency_file}`. Manually merge this journal with the default journal file when possible.",
                     mock_logger.call_args[0][0],


### PR DESCRIPTION
Some variable names, read-me and docstrings, etc.